### PR TITLE
Azure pipeline support for arm64 using qemu

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -17,6 +17,19 @@ pr:
 variables:
 - group: codecov
 
+resources:
+  containers:
+  - container: manylinux
+    image: quay.io/pypa/manylinux1_x86_64
+  repositories:
+  - repository: templates
+    type: github
+    name: aio-libs/azure-pipelines
+    endpoint: aio-libs
+
 stages:
 - template: stage-lint.yml
 - template: stage-test.yml
+- template: templates/stage-test-aarch64.yml@templates
+  parameters:
+    steps: $PYTHON setup.py install && $PYTHON -m pip install -r requirements/pytest.txt && \

--- a/.azure-pipelines/deploy.yml
+++ b/.azure-pipelines/deploy.yml
@@ -25,6 +25,10 @@ stages:
 
 - template: stage-test.yml
 
+- template: templates/stage-test-aarch64.yml@templates
+  parameters:
+    steps: $PYTHON setup.py install && $PYTHON -m pip install -r requirements/pytest.txt && \
+
 - stage: build
   displayName: 'Build'
 
@@ -150,6 +154,8 @@ stages:
             - script: |
                 python setup.py bdist_wheel
               displayName: 'Make wheel'
+
+- template: templates/stage-deploy-aarch64.yml@templates
 
 - template: templates/stage-publish.yml@templates
   parameters:


### PR DESCRIPTION
Package Owner: Disha Srivastava

PR change Details:
Added azure pipeline support for aarch64 using qemu.

Testing Detail :
Done testing. Below is the link of pipeline:
https://dev.azure.com/odidev0187/odidev/_build/results?buildId=36&view=logs&j=dce3830e-3833-5c60-a02d-556f0611b268&t=c58f4252-4270-58ec-4094-92b56b3846c5

Peer Reviewer: Madhukar

Reviewer: Pruthvi